### PR TITLE
fix: There is a case that the image creation could not be created usi…

### DIFF
--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,2 +1,2 @@
-export const OCR_IMAGES_PATH= './.tmp'
+export const OCR_IMAGES_PATH = './.tmp'
 export const SERVICE_NAME = require('../../package.json').name

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -21,8 +21,8 @@ export default async function createImage(data: CreateImageData) {
   const context = canvasImage.getContext('2d')
   const sxDx = left ? left : 0
   const syDy = top ? top : 0
-  const sdHeight = bottom && (top || top === 0) ? bottom - top : height
-  const sdWidth = (left || left === 0) && right ? right - left : width
+  const sdHeight = bottom && (top || top === 0) ? Math.abs (bottom - top ) : height
+  const sdWidth = (left || left === 0) && right ?  Math.abs (right - left ) : width
 
   context.drawImage(
     image,
@@ -44,10 +44,10 @@ export default async function createImage(data: CreateImageData) {
 
       context.beginPath()
       context.fillStyle = 'rgba(57, 170, 86, 0.5)'
-      context.fillRect(left, top, right - left, bottom - top)
+      context.fillRect(left, top, Math.abs(right - left ), Math.abs(bottom - top ))
       context.lineWidth = 2
       context.strokeStyle = '#39aa56'
-      context.rect(left, top, right - left, bottom - top)
+      context.rect(left, top, Math.abs(right - left ), Math.abs(bottom - top ))
       context.stroke()
     })
   }

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -22,7 +22,7 @@ export default async function createImage(data: CreateImageData) {
   const sxDx = left ? left : 0
   const syDy = top ? top : 0
   const sdHeight = bottom && (top || top === 0) ? Math.abs (bottom - top ) : height
-  const sdWidth = (left || left === 0) && right ?  Math.abs (left - right ) : width
+  const sdWidth = (left || left === 0) && right ?  Math.abs (right - left ) : width
 
   context.drawImage(
     image,
@@ -44,10 +44,10 @@ export default async function createImage(data: CreateImageData) {
 
       context.beginPath()
       context.fillStyle = 'rgba(57, 170, 86, 0.5)'
-      context.fillRect(left, top, Math.abs (left - right ), Math.abs(bottom - top ))
+      context.fillRect(left, top, Math.abs (right - left ), Math.abs(bottom - top ))
       context.lineWidth = 2
       context.strokeStyle = '#39aa56'
-      context.rect(left, top, Math.abs (left - right ), Math.abs(bottom - top ))
+      context.rect(left, top, Math.abs (right - left ), Math.abs(bottom - top ))
       context.stroke()
     })
   }

--- a/src/utils/createImage.ts
+++ b/src/utils/createImage.ts
@@ -22,7 +22,7 @@ export default async function createImage(data: CreateImageData) {
   const sxDx = left ? left : 0
   const syDy = top ? top : 0
   const sdHeight = bottom && (top || top === 0) ? Math.abs (bottom - top ) : height
-  const sdWidth = (left || left === 0) && right ?  Math.abs (right - left ) : width
+  const sdWidth = (left || left === 0) && right ?  Math.abs (left - right ) : width
 
   context.drawImage(
     image,
@@ -44,10 +44,10 @@ export default async function createImage(data: CreateImageData) {
 
       context.beginPath()
       context.fillStyle = 'rgba(57, 170, 86, 0.5)'
-      context.fillRect(left, top, Math.abs(right - left ), Math.abs(bottom - top ))
+      context.fillRect(left, top, Math.abs (left - right ), Math.abs(bottom - top ))
       context.lineWidth = 2
       context.strokeStyle = '#39aa56'
-      context.rect(left, top, Math.abs(right - left ), Math.abs(bottom - top ))
+      context.rect(left, top, Math.abs (left - right ), Math.abs(bottom - top ))
       context.stroke()
     })
   }


### PR DESCRIPTION
…ng a rectangle in options.

This PR should handle the case that the calculation of `sdHeight` or `sdWidth` in
`createImage()` will return a negative number instead of an
absolute.

Contributes to: #13

Signed-off-by: Georgios Romanas gromanas@gmail.com